### PR TITLE
added configuration from remote side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ desktop.ini
 .anvil
 *node_modules*
 *npm-debug*
+/.settings
+/.project

--- a/example/iframe.html
+++ b/example/iframe.html
@@ -10,11 +10,9 @@
     <script type="text/javascript" src="../lib/postal.federation.js"></script>
     <script type="text/javascript" src="../ext/postal.xframe.js"></script>
     <script type="text/javascript">
-        postal.instanceId("iframe1");
-        postal.fedx.addFilter([
-            { channel: 'postal',  topic: '#', direction: 'both'  },
-            { channel: 'parentz', topic: '#', direction: 'out' }
-        ]);
+        postal.instanceId(postal.utils.createUUID());
+
+
         postal.addWireTap(function(d, e) {
         	if(console && console.log){console.log( "ID: " + postal.instanceId() + " " + JSON.stringify( e, null, 4 ) );}
         	//console.debug( "ID: " + postal.instanceId() ,JSON.stringify( e, null, 4 ) );

--- a/example/iframe.html
+++ b/example/iframe.html
@@ -12,15 +12,22 @@
     <script type="text/javascript">
         postal.instanceId("iframe1");
         postal.fedx.addFilter([
-            { channel: 'postal',  topic: '#', direction: 'in'  },
-            { channel: 'iframez', topic: '#', direction: 'in'  },
+            { channel: 'postal',  topic: '#', direction: 'both'  },
             { channel: 'parentz', topic: '#', direction: 'out' }
         ]);
         postal.addWireTap(function(d, e) {
-            console.log("ID: " + postal.instanceId() + " - " + JSON.stringify(e, null, 4));
+        	if(console && console.log){console.log( "ID: " + postal.instanceId() + " " + JSON.stringify( e, null, 4 ) );}
+        	//console.debug( "ID: " + postal.instanceId() ,JSON.stringify( e, null, 4 ) );
         });
         postal.subscribe({
             channel: "iframez",
+            topic: "#",
+            callback: function(d, e) {
+                $("#msgs").append("<div><pre>" + JSON.stringify(e, null, 4) + "</pre></div>");
+            }
+        });
+        postal.subscribe({
+            channel: "postal",
             topic: "#",
             callback: function(d, e) {
                 $("#msgs").append("<div><pre>" + JSON.stringify(e, null, 4) + "</pre></div>");
@@ -37,17 +44,36 @@
                 });
             });
             $("#msg3").on('click', function(){
+                postal.publish({
+                    channel: "postal",
+                    topic: "some.topic",
+                    data: "This message will appear in all"
+                });
+            });
+            $("#msg4").on('click', function(){
                 postal.fedx.disconnect();
             });
 
-            postal.fedx.signalReady();
+       	 postal.publish({
+             channel: "postal",
+             topic: "not yet there",
+             data: "This message will appear in all"
+         });
+            postal.fedx.signalReady(function(){
+            	 postal.publish({
+                     channel: "postal",
+                     topic: "yeah i am there",
+                     data: "This message will appear in all"
+                 });
+            });
         });
     </script>
 </head>
 <body>
 <div>
     <input type="button" value="Send Msg" id="msg2">
-    <input type="button" value="Disconnect" id="msg3">
+    <input type="button" value="Send Broadcast Msg" id="msg3">
+    <input type="button" value="Disconnect" id="msg4">
 </div>
 <div id="msgs"></div>
 </body>

--- a/example/iframe2.html
+++ b/example/iframe2.html
@@ -10,17 +10,28 @@
     <script type="text/javascript" src="../lib/postal.federation.js"></script>
     <script type="text/javascript" src="../ext/postal.xframe.js"></script>
     <script type="text/javascript">
-        postal.instanceId("iframe2");
+        postal.instanceId("iframe2",  {allowInstanceIdUpdates : false});
         postal.fedx.addFilter([
-            { channel: 'postal',  topic: '#', direction: 'in'  },
+            { channel: 'postal',  topic: '#', direction: 'both'  },
             { channel: 'iframez', topic: '#', direction: 'in'  },
             { channel: 'parentz', topic: '#', direction: 'out' }
         ]);
+        postal.fedx.restrictRemoteConfig = function (data){
+        	return true;
+        }
         postal.addWireTap(function(d, e) {
-            console.log("ID: " + postal.instanceId() + " - " + JSON.stringify(e, null, 4));
+        	if(console && console.log){console.log( "ID: " + postal.instanceId() + " " + JSON.stringify( e, null, 4 ) );}
+        	//console.debug( "ID: " + postal.instanceId() , JSON.stringify( e, null, 4 ) );
         });
         postal.subscribe({
             channel: "iframez",
+            topic: "#",
+            callback: function(d, e) {
+                $("#msgs").append("<div><pre>" + JSON.stringify(e, null, 4) + "</pre></div>");
+            }
+        });
+        postal.subscribe({
+            channel: "postal",
             topic: "#",
             callback: function(d, e) {
                 $("#msgs").append("<div><pre>" + JSON.stringify(e, null, 4) + "</pre></div>");
@@ -37,6 +48,13 @@
                 });
             });
             $("#msg3").on('click', function(){
+                postal.publish({
+                    channel: "postal",
+                    topic: "some.topic",
+                    data: "This message will appear in all"
+                });
+            });
+            $("#msg4").on('click', function(){
                 postal.fedx.disconnect();
             });
 
@@ -47,7 +65,8 @@
 <body>
 <div>
     <input type="button" value="Send Msg" id="msg2">
-    <input type="button" value="Disconnect" id="msg3">
+    <input type="button" value="Send Broadcast Msg" id="msg3">
+    <input type="button" value="Disconnect" id="msg4">
 </div>
 <div id="msgs"></div>
 </body>

--- a/example/main.js
+++ b/example/main.js
@@ -10,7 +10,7 @@ postal.fedx.addFilter( [
 postal.fedx.onFederation = function(data){
 	  return {
 		instanceId : data.source.instanceId + "_ParentDefined",
-		filter : [
+		filters : [
 			{channel: 'channelB', topic: '#', direction: 'in'  }
 		 ]};
 };

--- a/example/main.js
+++ b/example/main.js
@@ -3,18 +3,33 @@
 postal.instanceId( "parent" );
 
 postal.fedx.addFilter( [
-	{ channel : 'postal', topic : '#', direction : 'out' },
+	{ channel : 'postal', topic : '#', direction : 'both' },
 	{ channel : 'iframez', topic : '#', direction : 'out' },
 	{ channel : 'parentz', topic : '#', direction : 'in'  }
 ] );
+postal.fedx.onFederation = function(data){
+	  return {
+		instanceId : data.source.instanceId + "_ParentDefined",
+		filter : [
+			{channel: 'channelB', topic: '#', direction: 'in'  }
+		 ]};
+};
 postal.addWireTap( function ( d, e ) {
-	console.log( "ID: " + postal.instanceId() + " " + JSON.stringify( e, null, 4 ) );
+	if(console && console.log){console.log( "ID: " + postal.instanceId() + " " + JSON.stringify( e, null, 4 ) );}
+	//console.debug( "ID: " + postal.instanceId() ,JSON.stringify( e, null, 4 ) );
 } );
 
 $( function () {
 
 	postal.subscribe( {
 		channel : "parentz",
+		topic : "#",
+		callback : function ( d, e ) {
+			$( "#msgs" ).append( "<div><pre>" + JSON.stringify( e, null, 4 ) + "</pre></div>" );
+		}
+	} );
+	postal.subscribe( {
+		channel : "postal",
 		topic : "#",
 		callback : function ( d, e ) {
 			$( "#msgs" ).append( "<div><pre>" + JSON.stringify( e, null, 4 ) + "</pre></div>" );

--- a/example/main.js
+++ b/example/main.js
@@ -11,8 +11,11 @@ postal.fedx.onFederation = function(data){
 	  return {
 		instanceId : data.source.instanceId + "_ParentDefined",
 		filters : [
-			{channel: 'channelB', topic: '#', direction: 'in'  }
-		 ]};
+		       	{ channel : 'postal', topic : '#', direction : 'both' },
+		    	{ channel : 'iframez', topic : '#', direction : 'out' },
+		    	{ channel : 'parentz', topic : '#', direction : 'in'  }
+		 ]
+	  };
 };
 postal.addWireTap( function ( d, e ) {
 	if(console && console.log){console.log( "ID: " + postal.instanceId() + " " + JSON.stringify( e, null, 4 ) );}

--- a/lib/postal.federation.js
+++ b/lib/postal.federation.js
@@ -32,7 +32,7 @@
   		s[19] = hexDigits.substr( (s[19] & 0x3) | 0x8, 1 );  // bits 6-7 of the clock_seq_hi_and_reserved to 01
   		s[8] = s[13] = s[18] = s[23] = "-";
   		return s.join( "" );
-  	}
+  	};
   }
   if ( !postal.instanceId ) {
   	postal.instanceId = (function () {
@@ -73,7 +73,7 @@
   				instanceId : postal.instanceId(),
   				timeStamp : new Date(),
   				ticket : postal.utils.createUUID()
-  			}
+  			};
   		},
   		pong : function ( ping ) {
   			return {
@@ -85,7 +85,15 @@
   					timeStamp : ping.timeStamp,
   					ticket : ping.ticket
   				}
-  			}
+  			};
+  		},
+  		remoteConfig : function ( object ) {
+  			return {
+  				type : 'federation.remoteConfig',
+  				instanceId : postal.instanceId(),
+  				timeStamp : new Date(),
+  				config : object
+  			};
   		},
   		message : function ( env ) {
   			return {
@@ -93,14 +101,14 @@
   				instanceId : postal.instanceId(),
   				timeStamp : new Date(),
   				envelope : env
-  			}
+  			};
   		},
   	    disconnect: function () {
   	      return {
   	        type : 'federation.disconnect',
   	        instanceId : postal.instanceId(),
   	        timeStamp : new Date()
-  	      }
+  	      };
   	    },
   		bundle : function ( packingSlips ) {
   			return {
@@ -108,20 +116,21 @@
   				instanceId : postal.instanceId(),
   				timeStamp : new Date(),
   				packingSlips : packingSlips
-  			}
+  			};
   		}
   	},
   	_handle = {
   		"federation.ping" : function ( data, callback ) {
   			data.source.setInstanceId(data.packingSlip.instanceId);
-  			if(data.source.handshakeComplete) {
-  				data.source.sendPong( data.packingSlip );
-  			} else {
-  				data.source.sendBundle( [
-  					postal.fedx.getPackingSlip( 'pong', data.packingSlip ),
-  					postal.fedx.getPackingSlip( 'ping' )
-  				] );
-  			}
+				var array = [postal.fedx.getPackingSlip( 'pong', data.packingSlip )];
+				if(!data.source.handshakeComplete) {
+		  			array.push(postal.fedx.getPackingSlip( 'ping' ));
+				}
+  				var config = postal.fedx.onFederation(data);
+  				if(config){
+  					array.unshift(postal.fedx.getPackingSlip( 'remoteConfig', config));
+  				}
+  				data.source.sendBundle(array );
   		},
   		"federation.pong" : function ( data ) {
   			data.source.handshakeComplete = true;
@@ -147,7 +156,19 @@
   				}
   			} );
   		},
-  	    "federation.disconnect" : function ( data ) {
+  		"federation.remoteConfig" : function ( data ) {
+  			if(data.packingSlip.config && !postal.fedx.restrictRemoteConfig(data)){
+  				var instanceId = data.packingSlip.config.instanceId;
+  				var filters = data.packingSlip.config.filters;
+  				if(instanceId){
+  					postal.instanceId(instanceId)
+  				};
+  				if(filters){
+  					postal.addFilters(filters);
+  				};
+  			}
+  		},
+  		"federation.disconnect" : function ( data ) {
   			postal.fedx.clients = _.without(postal.fedx.clients, data.source.instanceId);
   		    postal.fedx.disconnect({ transport: data.source.transportName, instanceId: data.source.instanceId, doNotNotify: true });
   	    },
@@ -170,7 +191,7 @@
   			return postal.configuration.resolver.compare( binding, topic );
   		} ));
   		var blacklisting = _config.filterMode === 'blacklist';
-  
+
   		return _config.enabled &&
   		       (
   			       (blacklisting && (!channelPresent || (channelPresent && !topicMatch))) ||
@@ -185,21 +206,21 @@
   		this.instanceId = instanceId;
   		this.handshakeComplete = false;
   	};
-  
+
   FederationClient.prototype.sendPing = function ( callback ) {
   	var packingSlip = postal.fedx.getPackingSlip( 'ping' );
   	this.pings[packingSlip.ticket] = { ticket : packingSlip.ticket, callback : callback || NO_OP };
   	this.send( packingSlip );
   };
-  
+
   FederationClient.prototype.sendPong = function ( origPackingSlip ) {
   	this.send( postal.fedx.getPackingSlip( 'pong', origPackingSlip ) );
   };
-  
+
   FederationClient.prototype.sendBundle = function ( slips ) {
   	this.send( postal.fedx.getPackingSlip( 'bundle', slips ) );
   };
-  
+
   FederationClient.prototype.sendMessage = function ( envelope ) {
   	if ( !this.handshakeComplete ) {
   		return;
@@ -214,11 +235,11 @@
   		this.send( postal.fedx.getPackingSlip( 'message', env ) );
   	}
   };
-  
+
   FederationClient.prototype.disconnect = function () {
   	this.send( postal.fedx.getPackingSlip( 'disconnect' ) );
   };
-  
+
   FederationClient.prototype.onMessage = function ( packingSlip ) {
   	if ( this.shouldProcess() ) {
   		postal.fedx.onFederatedMsg( {
@@ -228,32 +249,32 @@
   		} );
   	}
   };
-  
+
   FederationClient.prototype.shouldProcess = function () {
   	return true;
   };
-  
+
   FederationClient.prototype.send = function ( msg ) {
   	throw new Error( "An object deriving from FederationClient must provide an implementation for 'send'." );
   };
-  
+
   FederationClient.prototype.setInstanceId = function( id ) {
   	this.instanceId = id;
   };
-  
+
   riveter( FederationClient );
-  
+
   postal.fedx = _.extend( {
-  
+
   	FederationClient : FederationClient,
-  
+
   	clients: [],
-  
+
   	transports : {},
-  	
+
   	// in is a reserved word (IE 8)
   	filters : { "in" : {}, "out" : {} },
-  
+
   	addFilter : function ( filters ) {
   		filters = _.isArray( filters ) ? filters : [ filters ];
   		_.each( filters, function ( filter ) {
@@ -267,7 +288,7 @@
   			}, this );
   		}, this );
   	},
-  
+
   	removeFilter : function ( filters ) {
   		filters = _.isArray( filters ) ? filters : [ filters ];
   		_.each( filters, function ( filter ) {
@@ -279,11 +300,11 @@
   			}, this );
   		}, this );
   	},
-  
+
   	canSendRemote : function ( channel, topic ) {
   		return _matchesFilter( channel, topic, 'out' );
   	},
-  
+
   	configure : function ( cfg ) {
   		if ( cfg && cfg.filterMode && cfg.filterMode !== 'blacklist' && cfg.filterMode !== 'whitelist' ) {
   			throw new Error( "postal.fedx filterMode must be 'blacklist' or 'whitelist'." );
@@ -293,13 +314,13 @@
   		}
   		return _config;
   	},
-  
+
   	getPackingSlip : function ( type, env ) {
   		if (Object.prototype.hasOwnProperty.call(_packingSlips, type)) {
   			return _packingSlips[type].apply( this, Array.prototype.slice.call( arguments, 1 ) );
   		}
   	},
-  
+
   	onFederatedMsg : function ( data ) {
   		if ( !_ready ) {
   			_inboundQueue.push( data );
@@ -311,7 +332,7 @@
   			throw new Error( "postal.federation does not have a message handler for '" + data.packingSlip.type + "'." );
   		}
   	},
-  
+
   	sendMessage : function ( envelope ) {
   		if ( !_ready ) {
   			_outboundQueue.push( arguments );
@@ -321,7 +342,7 @@
   			transport.sendMessage( envelope );
   		} );
   	},
-  
+
   	disconnect : function ( options ) {
   		options = options || {};
   		var transports = this.transports;
@@ -337,14 +358,16 @@
   			});
   		}, this);
   	},
-  
+
   	_getTransports : function ( ) {
   		return _.reduce( this.transports, function ( memo, transport, name ) {
   		  memo[name] = true;
   		  return memo;
   		}, {} );
   	},
-  
+
+  	onFederation : NO_OP,
+  	restrictRemoteConfig : NO_OP,
   	/*
   	signalReady( callback );
   	signalReady( "transportName" );
@@ -387,15 +410,15 @@
   			this.transports[name].signalReady( targets, callback );
   		}, this );
   	}
-  
+
   }, postal.fedx );
-  
+
   postal.addWireTap( function ( data, envelope ) {
   	if ( postal.fedx.canSendRemote( envelope.channel, envelope.topic ) ) {
   		postal.fedx.sendMessage( envelope );
   	}
   } );
-  
+
   postal.subscribe( {
   	channel : postal.configuration.SYSTEM_CHANNEL,
   	topic : "instanceId.changed",
@@ -418,7 +441,7 @@
   		}
   	}
   } );
-  
+
   if ( postal.instanceId() !== undefined ) {
   	_ready = true;
   }

--- a/lib/postal.federation.js
+++ b/lib/postal.federation.js
@@ -161,10 +161,10 @@
   				var instanceId = data.packingSlip.config.instanceId;
   				var filters = data.packingSlip.config.filters;
   				if(instanceId){
-  					postal.instanceId(instanceId)
+  					postal.instanceId(instanceId);
   				};
   				if(filters){
-  					postal.addFilters(filters);
+  					postal.fedx.addFilter(filters);
   				};
   			}
   		},
@@ -366,8 +366,24 @@
   		}, {} );
   	},
 
+  	/*
+  	 * handler in the parent to return the configuration data for the signalling client. the input for the function is the ping data.
+  	 * Must return a config data object with instanceId and/or filters. additional data is sent to tht client but not handled.
+  	 * {
+		instanceId : "newInstanceId",
+		filters : [
+		    	{ channel : 'parentz', topic : '#', direction : 'in'  }
+		 ]};
+  	 * postal.fedx.onFederation = function(data){}
+  	*/
   	onFederation : NO_OP,
+
+  	/*
+  	 * handler in the client to prevent a remote config from beeing applied. Must return a boolean value
+  	 * postal.fedx.restrictRemoteConfig = function(data){}
+  	*/
   	restrictRemoteConfig : NO_OP,
+
   	/*
   	signalReady( callback );
   	signalReady( "transportName" );

--- a/src/federation.js
+++ b/src/federation.js
@@ -138,10 +138,10 @@ var NO_OP = function() {},
   				var instanceId = data.packingSlip.config.instanceId;
   				var filters = data.packingSlip.config.filters;
   				if(instanceId){
-  					postal.instanceId(instanceId)
+  					postal.instanceId(instanceId);
   				};
   				if(filters){
-  					postal.addFilters(filters);
+  					postal.fedx.addFilter(filters);
   				};
   			}
   		},
@@ -343,7 +343,22 @@ postal.fedx = _.extend( {
 		}, {} );
 	},
 
+  	/*
+  	 * handler in the parent to return the configuration data for the signalling client. the input for the function is the ping data.
+  	 * Must return a config data object with instanceId and/or filters. additional data is sent to tht client but not handled.
+  	 * {
+		instanceId : "newInstanceId",
+		filters : [
+		    	{ channel : 'parentz', topic : '#', direction : 'in'  }
+		 ]};
+  	 * postal.fedx.onFederation = function(data){}
+  	*/
   	onFederation : NO_OP,
+
+  	/*
+  	 * handler in the client to prevent a remote config from beeing applied. Must return a boolean value
+  	 * postal.fedx.restrictRemoteConfig = function(data){}
+  	*/
   	restrictRemoteConfig : NO_OP,
 	/*
 	signalReady( callback );


### PR DESCRIPTION
With this change it is possible to allow the parent to define the instanceId of the iframe. It is also possible to define the filter configuration the same way. 
@see postaljs/postal.federation#6
