### PR TITLE
Create a postal.utils object if it doesn't exist

### DIFF
--- a/src/federation.js
+++ b/src/federation.js
@@ -1,3 +1,4 @@
+postal.utils = postal.utils || {};
 if ( !postal.utils.createUUID ) {
 	postal.utils.createUUID = function () {
 		var s = [];


### PR DESCRIPTION
It looks like recent versions of postal.js lack a postal.utils namespace so the check for postal.utils.createUUID results in an error. This fix allows the check to proceed without error and gives us a place to assign createUUID.