### PR TITLE
Change CommonJS imports away from dependency injection

### DIFF
--- a/src/postal.federation.js
+++ b/src/postal.federation.js
@@ -1,9 +1,7 @@
 (function(root, factory) {
     if (typeof module === "object" && module.exports) {
         // Node, or CommonJS-Like environments
-        module.exports = function(_, postal, riveter) {
-            return factory(_, postal, riveter);
-        };
+        module.exports = factory(require("lodash"), require("postal"), require("riveter"));
     } else if (typeof define === "function" && define.amd) {
         // AMD. Register as an anonymous module.
         define(["lodash", "postal", "riveter"], function(_, postal, riveter) {


### PR DESCRIPTION
postal.xframe has been updated to not use dependency injection in its CommonJS imports, but postal.federation was still using them, causing an error.
Still, extend is undefined in postal.fedx.FederationClient.extend so this is only a partial fix.