### PR TITLE
Added necessary bower dependencies to make this lib work when installing...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
     "dependencies": {
         "lodash": "~2.4.1",
         "postal.js": ">=0.8.11",
-        "postal.xframe": "~0.2.3",
         "riveter": "~0.1.2"
     },
     "devDependencies": {


### PR DESCRIPTION
... via bower.

When doing a bower install this lib was not downloading the necessary dependent scripts by default.
This caused a crash in the lib.

This commit fixes this issue and now installing via bower downloads the necessary dependencies.
