### PR TITLE
Add Postal and BabelCore as DevDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "babel": "5.x",
+    "babel-core": "^4.7.16",
     "babel-loader": "~4.0.0",
     "eslint": "^1.3.1",
     "expect.js": "~0.2.0",
@@ -71,6 +72,7 @@
     "karma-spec-reporter": "0.0.20",
     "mocha": "^2.3.0",
     "open": "~0.0.4",
+    "postal": ">=1.x",
     "postal.xframe": "~0.3.0",
     "webpack": "^1.12.1",
     "webpack-stream": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "karma-spec-reporter": "0.0.20",
     "mocha": "^2.3.0",
     "open": "~0.0.4",
-    "postal": ">=1.x",
+    "postal": "^2.0.4",
     "postal.xframe": "~0.3.0",
     "webpack": "^1.12.1",
     "webpack-stream": "^2.1.0"


### PR DESCRIPTION
`npm test` was failing due to postal missing from `node_modules`. I'm adding it to the devDependencies so that the tests can run cleanly.